### PR TITLE
release v0.2.0

### DIFF
--- a/clusters/formkube-test.sandermann.cloud/vars.tfvars
+++ b/clusters/formkube-test.sandermann.cloud/vars.tfvars
@@ -33,6 +33,7 @@ platform_resource_tags_additional={"ClusterType" = "K8S_14.03"}
 /////////////////////////////////////////////////////BASTIONS///////////////////////////////////////////////////////////
 
 bastions_amount="1"
+bastions_fault_domains = "2"
 bastions_vm_type="Standard_DS1_v2"
 bastions_vm_prefix="bastion"
 bastions_admin_username="kevin"
@@ -48,6 +49,7 @@ bastions_os_image_version="latest"
 /////////////////////////////////////////////////////MASTERS////////////////////////////////////////////////////////////
 
 masters_amount="0"
+masters_fault_domains = "2"
 masters_vm_type="Standard_DS1_v2"
 masters_vm_prefix="master"
 masters_admin_username="kevin"

--- a/clusters/formkube-test.sandermann.cloud/vars.tfvars
+++ b/clusters/formkube-test.sandermann.cloud/vars.tfvars
@@ -66,6 +66,7 @@ masters_os_image_version="latest"
 /////////////////////////////////////////////////////COMPUTENODES///////////////////////////////////////////////////////
 
 computenodes_amount="0"
+computenodes_fault_domains = "2"
 computenodes_vm_type="Standard_DS1_v2"
 computenodes_vm_prefix="computenode"
 computenodes_admin_username="kevin"
@@ -81,6 +82,7 @@ computenodes_os_image_version="latest"
 /////////////////////////////////////////////////////INFRANODES/////////////////////////////////////////////////////////
 
 infranodes_amount="0"
+infranodes_fault_domains = "2"
 infranodes_vm_type="Standard_DS1_v2"
 infranodes_vm_prefix="infranode"
 infranodes_admin_username="clusteradmin"

--- a/clusters/samplecluster-dev.example.com/vars.tfvars
+++ b/clusters/samplecluster-dev.example.com/vars.tfvars
@@ -49,6 +49,7 @@ bastions_os_image_version="latest"
 /////////////////////////////////////////////////////MASTERS////////////////////////////////////////////////////////////
 
 masters_amount="1"
+masters_fault_domains = "2"
 masters_vm_type="Standard_D4_v3"
 masters_vm_prefix="master"
 masters_admin_username="clusteradmin"

--- a/clusters/samplecluster-dev.example.com/vars.tfvars
+++ b/clusters/samplecluster-dev.example.com/vars.tfvars
@@ -66,6 +66,7 @@ masters_os_image_version="latest"
 /////////////////////////////////////////////////////COMPUTENODES///////////////////////////////////////////////////////
 
 computenodes_amount="1"
+computenodes_fault_domains = "2"
 computenodes_vm_type="Standard_D4_v3"
 computenodes_vm_prefix="computenode"
 computenodes_admin_username="clusteradmin"
@@ -81,6 +82,7 @@ computenodes_os_image_version="latest"
 /////////////////////////////////////////////////////INFRANODES/////////////////////////////////////////////////////////
 
 infranodes_amount="1"
+infranodes_fault_domains = "2"
 infranodes_vm_type="Standard_D4_v3"
 infranodes_vm_prefix="infranode"
 infranodes_admin_username="clusteradmin"

--- a/clusters/samplecluster-dev.example.com/vars.tfvars
+++ b/clusters/samplecluster-dev.example.com/vars.tfvars
@@ -33,6 +33,7 @@ platform_resource_tags_additional={"ClusterType" = "K8S_14.03"}
 /////////////////////////////////////////////////////BASTIONS///////////////////////////////////////////////////////////
 
 bastions_amount="1"
+bastions_fault_domains = "2"
 bastions_vm_type="Standard_DS1_v2"
 bastions_vm_prefix="bastion"
 bastions_admin_username="clusteradmin"

--- a/clusters/samplecluster-prd.example.com/vars.tfvars
+++ b/clusters/samplecluster-prd.example.com/vars.tfvars
@@ -33,6 +33,7 @@ platform_resource_tags_additional={"ClusterType" = "K8S_14.03"}
 /////////////////////////////////////////////////////BASTIONS///////////////////////////////////////////////////////////
 
 bastions_amount="2"
+bastions_fault_domains = "2"
 bastions_vm_type="Standard_DS1_v2"
 bastions_vm_prefix="bastion"
 bastions_admin_username="clusteradmin"

--- a/clusters/samplecluster-prd.example.com/vars.tfvars
+++ b/clusters/samplecluster-prd.example.com/vars.tfvars
@@ -49,6 +49,7 @@ bastions_os_image_version="latest"
 /////////////////////////////////////////////////////MASTERS////////////////////////////////////////////////////////////
 
 masters_amount="3"
+masters_fault_domains = "2"
 masters_vm_type="Standard_D4_v3"
 masters_vm_prefix="master"
 masters_admin_username="clusteradmin"

--- a/clusters/samplecluster-prd.example.com/vars.tfvars
+++ b/clusters/samplecluster-prd.example.com/vars.tfvars
@@ -66,6 +66,7 @@ masters_os_image_version="latest"
 /////////////////////////////////////////////////////COMPUTENODES///////////////////////////////////////////////////////
 
 computenodes_amount="3"
+computenodes_fault_domains = "2"
 computenodes_vm_type="Standard_D8_v3"
 computenodes_vm_prefix="computenode"
 computenodes_admin_username="clusteradmin"
@@ -81,6 +82,7 @@ computenodes_os_image_version="latest"
 /////////////////////////////////////////////////////INFRANODES/////////////////////////////////////////////////////////
 
 infranodes_amount="3"
+infranodes_fault_domains = "2"
 infranodes_vm_type="Standard_D8_v3"
 infranodes_vm_prefix="infranode"
 infranodes_admin_username="clusteradmin"

--- a/docs/tectonic_comparison.md
+++ b/docs/tectonic_comparison.md
@@ -2,19 +2,21 @@
 
 As FormKube does **not** bootstrap Kubernetes or OpenShift itself, the most known product to compare it to would be
 [tectonic-installer](https://github.com/coreos/tectonic-installer). As 
-[this blogpost](https://coreos.com/blog/coreos-tech-to-combine-with-red-hat-openshift) states, tectonic is currently 
-being merged with Red Hat's OpenShift into [openshift-installer](https://github.com/openshift/installer).
+[this blogpost](https://coreos.com/blog/coreos-tech-to-combine-with-red-hat-openshift) states, tectonic-installer
+is currently being merged with Red Hat's OpenShift into [openshift-installer](https://github.com/openshift/installer).
+As the documentation states, tectonic-installer will not get any more features. Also, in the current state 
+openshift-installer does not support Azure (yet).
 Therefore, it is reasonable to compare FormKube with both of these tools.
 For additional information on how to install Kubernetes or OpenShift on the infrastructure provisioned by FormKube,
 please see the [Post Installation Guide](post_install_guide.md).
 
 
-| Feature                         	|  FormKube  	| TectonicInstaller@Azure 	| OpenShift Installer@Azure 	|
-|-----------------------------------|---------------|---------------------------|-------------------------------|
-| Kubernetes Support              	|     Yes    	|           Yes           	| Azure not supported (yet) 	|
-| OpenShift Support               	|     Yes    	|            No           	| Azure not supported (yet) 	|
-| High Availability               	| multi-zone 	|  multi-rack (one zone)  	| Azure not supported (yet) 	|
-| Automated Infrastructure Backup 	|     Yes    	|            No           	| Azure not supported (yet) 	|
+| Feature                         	|  FormKube  	            | TectonicInstaller@Azure 	| OpenShift Installer@Azure 	|
+|-----------------------------------|---------------------------|---------------------------|-------------------------------|
+| Kubernetes Support              	|     Yes    	            |           Yes           	| Azure not supported (yet) 	|
+| OpenShift Support               	|     Yes    	            |            No           	| Azure not supported (yet) 	|
+| High Availability               	| multi-rack (one region) 	|  multi-rack (one region)  | Azure not supported (yet) 	|
+| Automated Infrastructure Backup 	|     Yes    	            |            No           	| Azure not supported (yet) 	|
 
 
 # Authors

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,9 +1,11 @@
 # Version History
 
-| FormKube | Bootstrap environment                   | Terraform | recommended Docker |
-|----------|-----------------------------------------|-----------|--------------------|
-| 0.1.0    | ksandermann/cloud-toolbox:2019-07-18_01 | 0.12.4    | 18.09.2            |
-|          |                                         |           |                    |
+| FormKube | Bootstrap environment                   | Terraform | recommended Docker | release notes                                                           |
+|----------|-----------------------------------------|-----------|--------------------|-------------------------------------------------------------------------|
+| 0.2.0    | ksandermann/cloud-toolbox:2019-07-18_01 | 0.12.4    | 18.09.2            | [v0.2.0](https://github.com/ksandermann/formkube/releases/tag/v0.2.0)   |
+| 0.1.1    | ksandermann/cloud-toolbox:2019-07-18_01 | 0.12.4    | 18.09.2            | [v0.1.1](https://github.com/ksandermann/formkube/releases/tag/v0.1.1)   |
+| 0.1.0    | ksandermann/cloud-toolbox:2019-07-18_01 | 0.12.4    | 18.09.2            | [v0.1.0](https://github.com/ksandermann/formkube/releases/tag/v0.1.0)   |
+
 
 # Authors
 1. [ksandermann](https://github.com/ksandermann)

--- a/modules/azure/bastions/as.tf
+++ b/modules/azure/bastions/as.tf
@@ -1,0 +1,10 @@
+resource "azurerm_availability_set" "bastions" {
+  name                          = "${var.bastions_vm_prefix}s.${var.platform_fqdn}"
+  location                      = var.platform_location
+  resource_group_name           = var.out_platform_rg_name
+  managed                       = true
+  platform_fault_domain_count   = var.bastions_fault_domains
+  platform_update_domain_count  = (var.bastions_fault_domains > 1)  ? 3 : 2
+  tags                          = var.cluster_resource_tags
+
+}

--- a/modules/azure/bastions/vars.tf
+++ b/modules/azure/bastions/vars.tf
@@ -22,6 +22,11 @@ variable "bastions_amount" {
   description = "Number of bastions to create."
 }
 
+variable "bastions_fault_domains" {
+  type = "string"
+  description = "Number of fault domains for the availibility set of the bastions. This is depending on the region that you are using. https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/managed-disks-common-fault-domain-region-list.md"
+}
+
 variable "bastions_vm_type" {
   type = "string"
   description = "Type of the vm for the bastion. Example: Standard_DS1_v2"

--- a/modules/azure/bastions/vars.tf
+++ b/modules/azure/bastions/vars.tf
@@ -5,14 +5,14 @@ variable "out_platform_rg_name" {
   description = "Name of the resource group to create for the cluster. It is recommended to not use an existing rg. Example: k8s-dev.example.com"
 }
 
-variable "cluster_location" {
+variable "platform_location" {
   type = "string"
   description = "Region of the resource group to create for the cluster. It is recommended to not use an existing rg. Example: westeurope"
 }
 
-variable "cluster_fqdn" {
+variable "platform_fqdn" {
   type = "string"
-  description = "FQDN of the cluster. Example: k8s-dev.exmaple.com"
+  description = "FQDN of the cluster. Example: k8s-dev.example.com"
 }
 
 /////////////////////////////////////////////////////BASTIONS///////////////////////////////////////////////////////////

--- a/modules/azure/bastions/vms.tf
+++ b/modules/azure/bastions/vms.tf
@@ -1,3 +1,15 @@
+resource "azurerm_availability_set" "bastions" {
+  name                          = "${var.bastions_vm_prefix}s.${var.cluster_fqdn}"
+  location                      = var.cluster_location
+  resource_group_name           = var.out_platform_rg_name
+  managed                       = true
+  platform_fault_domain_count   = var.bastions_fault_domains
+  platform_update_domain_count  = (var.bastions_fault_domains > 1)  ? 3 : 2
+  tags                          = var.cluster_resource_tags
+
+}
+
+
 resource "azurerm_virtual_machine" "bastions" {
   count                             = var.bastions_amount
   name                              = "${var.bastions_vm_prefix}${count.index +1}.${var.cluster_fqdn}"
@@ -6,11 +18,10 @@ resource "azurerm_virtual_machine" "bastions" {
   network_interface_ids             = [var.out_bastions_subnet_nics_ids[count.index]]
   primary_network_interface_id      =  var.out_bastions_subnet_nics_ids[count.index]
   vm_size                           = var.bastions_vm_type
-  //use modulo 3 as only regions with 3 av. zones are supported
-  zones                             = [(count.index%3)+1]
   tags                              = var.cluster_resource_tags
   delete_os_disk_on_termination     = true
   delete_data_disks_on_termination  = true
+  availability_set_id               = azurerm_availability_set.bastions.id
 
   //LRS for OS disks is sufficient as bastion functionality is not crucial for cluster operations
   storage_image_reference {
@@ -43,4 +54,12 @@ resource "azurerm_virtual_machine" "bastions" {
       path                          = "/home/${var.bastions_admin_username}/.ssh/authorized_keys"
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      "storage_os_disk",
+      "storage_data_disk",
+    ]
+  }
+
 }

--- a/modules/azure/bastions/vms.tf
+++ b/modules/azure/bastions/vms.tf
@@ -1,6 +1,6 @@
 resource "azurerm_availability_set" "bastions" {
-  name                          = "${var.bastions_vm_prefix}s.${var.cluster_fqdn}"
-  location                      = var.cluster_location
+  name                          = "${var.bastions_vm_prefix}s.${var.platform_fqdn}"
+  location                      = var.platform_location
   resource_group_name           = var.out_platform_rg_name
   managed                       = true
   platform_fault_domain_count   = var.bastions_fault_domains
@@ -12,8 +12,8 @@ resource "azurerm_availability_set" "bastions" {
 
 resource "azurerm_virtual_machine" "bastions" {
   count                             = var.bastions_amount
-  name                              = "${var.bastions_vm_prefix}${count.index +1}.${var.cluster_fqdn}"
-  location                          = var.cluster_location
+  name                              = "${var.bastions_vm_prefix}${count.index +1}.${var.platform_fqdn}"
+  location                          = var.platform_location
   resource_group_name               = var.out_platform_rg_name
   network_interface_ids             = [var.out_bastions_subnet_nics_ids[count.index]]
   primary_network_interface_id      =  var.out_bastions_subnet_nics_ids[count.index]
@@ -32,7 +32,7 @@ resource "azurerm_virtual_machine" "bastions" {
   }
 
   storage_os_disk {
-    name                            = "${var.bastions_vm_prefix}${count.index +1}.${var.cluster_fqdn}-${var.bastions_os_disk_suffix}"
+    name                            = "${var.bastions_vm_prefix}${count.index +1}.${var.platform_fqdn}-${var.bastions_os_disk_suffix}"
     caching                         = "None"
     create_option                   = "FromImage"
     managed_disk_type               = var.bastions_os_disk_type
@@ -42,7 +42,7 @@ resource "azurerm_virtual_machine" "bastions" {
   }
 
   os_profile {
-    computer_name                   = "${var.bastions_vm_prefix}${count.index +1}.${var.cluster_fqdn}"
+    computer_name                   = "${var.bastions_vm_prefix}${count.index +1}.${var.platform_fqdn}"
     admin_username                  = var.bastions_admin_username
     admin_password                  = ""
   }

--- a/modules/azure/bastions/vms.tf
+++ b/modules/azure/bastions/vms.tf
@@ -1,15 +1,3 @@
-resource "azurerm_availability_set" "bastions" {
-  name                          = "${var.bastions_vm_prefix}s.${var.platform_fqdn}"
-  location                      = var.platform_location
-  resource_group_name           = var.out_platform_rg_name
-  managed                       = true
-  platform_fault_domain_count   = var.bastions_fault_domains
-  platform_update_domain_count  = (var.bastions_fault_domains > 1)  ? 3 : 2
-  tags                          = var.cluster_resource_tags
-
-}
-
-
 resource "azurerm_virtual_machine" "bastions" {
   count                             = var.bastions_amount
   name                              = "${var.bastions_vm_prefix}${count.index +1}.${var.platform_fqdn}"
@@ -22,6 +10,7 @@ resource "azurerm_virtual_machine" "bastions" {
   delete_os_disk_on_termination     = true
   delete_data_disks_on_termination  = true
   availability_set_id               = azurerm_availability_set.bastions.id
+  depends_on                        = [azurerm_availability_set.bastions]
 
   //LRS for OS disks is sufficient as bastion functionality is not crucial for cluster operations
   storage_image_reference {

--- a/modules/azure/masters/as.tf
+++ b/modules/azure/masters/as.tf
@@ -1,6 +1,6 @@
 resource "azurerm_availability_set" "masters" {
   name                          = "${var.masters_vm_prefix}s.${var.cluster_fqdn}"
-  location                      = var.platform_resource_tags
+  location                      = var.out_platform_rg_name
   resource_group_name           = var.out_platform_rg_name
   managed                       = true
   platform_fault_domain_count   = var.masters_fault_domains

--- a/modules/azure/masters/as.tf
+++ b/modules/azure/masters/as.tf
@@ -1,0 +1,12 @@
+resource "azurerm_availability_set" "masters" {
+  name                          = "${var.masters_vm_prefix}s.${var.cluster_fqdn}"
+  location                      = var.platform_resource_tags
+  resource_group_name           = var.out_platform_rg_name
+  managed                       = true
+  platform_fault_domain_count   = var.masters_fault_domains
+  //more than 6 masters doesn't make sense
+  platform_update_domain_count  = (var.masters_fault_domains > 1) ? 6 : 3
+  tags                          = var.platform_resource_tags
+
+}
+

--- a/modules/azure/masters/as.tf
+++ b/modules/azure/masters/as.tf
@@ -1,6 +1,6 @@
 resource "azurerm_availability_set" "masters" {
   name                          = "${var.masters_vm_prefix}s.${var.cluster_fqdn}"
-  location                      = var.out_platform_rg_name
+  location                      = var.platform_location
   resource_group_name           = var.out_platform_rg_name
   managed                       = true
   platform_fault_domain_count   = var.masters_fault_domains

--- a/modules/azure/masters/vars.tf
+++ b/modules/azure/masters/vars.tf
@@ -22,6 +22,11 @@ variable "masters_amount" {
   description = "Number of masters to create."
 }
 
+variable "masters_fault_domains" {
+  type = "string"
+  description = "Number of fault domains for the availibility set of the masters. This is depending on the region that you are using. https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/managed-disks-common-fault-domain-region-list.md"
+}
+
 variable "masters_vm_prefix" {
   type    = "string"
   description = "Prefix of the name of the vm resource for the masters. Resource name will be build with pattern (masters_vm_prefix)(index).cluster_name.cluster_domain . Example: master"

--- a/modules/azure/masters/vms.tf
+++ b/modules/azure/masters/vms.tf
@@ -1,16 +1,3 @@
-resource "azurerm_availability_set" "masters" {
-  name                          = "${var.masters_vm_prefix}s.${var.cluster_fqdn}"
-  location                      = var.platform_resource_tags
-  resource_group_name           = var.out_platform_rg_name
-  managed                       = true
-  platform_fault_domain_count   = var.masters_fault_domains
-  //more than 6 masters doesn't make sense
-  platform_update_domain_count  = (var.masters_fault_domains > 1) ? 6 : 3
-  tags                          = var.platform_resource_tags
-
-}
-
-
 resource "azurerm_virtual_machine" "masters" {
   count                             = var.masters_amount
   name                              = "${var.masters_vm_prefix}${count.index +1}.${var.cluster_fqdn}"
@@ -22,6 +9,7 @@ resource "azurerm_virtual_machine" "masters" {
   delete_os_disk_on_termination     = var.masters_os_disk_delete_on_destroy
   delete_data_disks_on_termination  = true
   availability_set_id               = azurerm_availability_set.masters.id
+  depends_on                        = [azurerm_availability_set.masters]
 
   //LRS for OS disks is sufficient as application data will be placed on seperate disks anyway
   storage_image_reference {

--- a/modules/azure/nodes/as.tf
+++ b/modules/azure/nodes/as.tf
@@ -12,7 +12,7 @@ resource "azurerm_availability_set" "computenodes" {
 
 resource "azurerm_availability_set" "infranodes" {
   name                          = "${var.infranodes_vm_prefix}s.${var.cluster_fqdn}"
-  location                      = var.platform_resource_tags
+  location                      = var.platform_location
   resource_group_name           = var.out_platform_rg_name
   managed                       = true
   platform_fault_domain_count   = var.infranodes_fault_domains

--- a/modules/azure/nodes/as.tf
+++ b/modules/azure/nodes/as.tf
@@ -1,0 +1,23 @@
+resource "azurerm_availability_set" "computenodes" {
+  name                          = "${var.computenodes_vm_prefix}s.${var.cluster_fqdn}"
+  location                      = var.platform_resource_tags
+  resource_group_name           = var.out_platform_rg_name
+  managed                       = true
+  platform_fault_domain_count   = var.computenodes_fault_domains
+  //more than 6 computenodes doesn't make sense
+  platform_update_domain_count  = (var.computenodes_fault_domains > 1) ? 6 : 3
+  tags                          = var.platform_resource_tags
+
+}
+
+resource "azurerm_availability_set" "infranodes" {
+  name                          = "${var.infranodes_vm_prefix}s.${var.cluster_fqdn}"
+  location                      = var.platform_resource_tags
+  resource_group_name           = var.out_platform_rg_name
+  managed                       = true
+  platform_fault_domain_count   = var.infranodes_fault_domains
+  //more than 6 infranodes doesn't make sense
+  platform_update_domain_count  = (var.infranodes_fault_domains > 1) ? 6 : 3
+  tags                          = var.platform_resource_tags
+
+}

--- a/modules/azure/nodes/as.tf
+++ b/modules/azure/nodes/as.tf
@@ -1,6 +1,6 @@
 resource "azurerm_availability_set" "computenodes" {
   name                          = "${var.computenodes_vm_prefix}s.${var.cluster_fqdn}"
-  location                      = var.platform_resource_tags
+  location                      = var.platform_location
   resource_group_name           = var.out_platform_rg_name
   managed                       = true
   platform_fault_domain_count   = var.computenodes_fault_domains

--- a/modules/azure/nodes/vars.tf
+++ b/modules/azure/nodes/vars.tf
@@ -28,6 +28,11 @@ variable "computenodes_amount" {
   description = "Number of compute nodes to create."
 }
 
+variable "computenodes_fault_domains" {
+  type = "string"
+  description = "Number of fault domains for the availibility set of the computenodes. This is depending on the region that you are using. https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/managed-disks-common-fault-domain-region-list.md"
+}
+
 variable "computenodes_vm_type" {
   type = "string"
   description = "Type of the vm for the compute nodes. Example: Standard_DS1_v2"
@@ -88,6 +93,11 @@ variable "computenodes_os_image_version" {
 variable "infranodes_amount" {
   type    = "string"
   description = "Number of infra nodes to create."
+}
+
+variable "infranodes_fault_domains" {
+  type = "string"
+  description = "Number of fault domains for the availibility set of the infranodes. This is depending on the region that you are using. https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/managed-disks-common-fault-domain-region-list.md"
 }
 
 variable "infranodes_vm_type" {

--- a/modules/azure/vnet/ips.tf
+++ b/modules/azure/vnet/ips.tf
@@ -6,5 +6,4 @@ resource "azurerm_public_ip" "bastions" {
   ip_version          = "IPv4"
   allocation_method   = "Static"
   tags                = var.platform_resource_tags
-  zones               = [(count.index%3)+1]
 }

--- a/providers/azure/main.tf
+++ b/providers/azure/main.tf
@@ -111,8 +111,8 @@ module "bastions" {
   source = "../../modules/azure/bastions"
 
   //cluster
-  cluster_fqdn = local.cluster_fqdn
-  cluster_location  = var.platform_location
+  platform_fqdn = local.cluster_fqdn
+  platform_location  = var.platform_location
   cluster_resource_tags = local.platform_all_resource_tags
 
   //bastions
@@ -150,6 +150,7 @@ module "masters" {
 
   //masters
   masters_amount = var.masters_amount
+  masters_fault_domains = var.masters_fault_domains
   masters_vm_type = var.masters_vm_type
   masters_vm_prefix = var.masters_vm_prefix
   masters_os_disk_suffix = var.masters_os_disk_suffix
@@ -166,6 +167,7 @@ module "masters" {
   //dependencies
   out_platform_rg_name = module.essentials.out_platform_rg_name
   out_masters_nics_ids = module.vnet.out_masters_nics_ids
+
 
 }
 

--- a/providers/azure/main.tf
+++ b/providers/azure/main.tf
@@ -181,6 +181,7 @@ module "nodes" {
 
   //computenodes
   computenodes_amount = var.computenodes_amount
+  computenodes_fault_domains = var.computenodes_fault_domains
   computenodes_vm_type = var.computenodes_vm_type
   computenodes_vm_prefix = var.computenodes_vm_prefix
   computenodes_os_disk_suffix = var.computenodes_os_disk_suffix
@@ -196,6 +197,7 @@ module "nodes" {
 
   //infranodes
   infranodes_amount = var.infranodes_amount
+  infranodes_fault_domains = var.infranodes_fault_domains
   infranodes_vm_type = var.infranodes_vm_type
   infranodes_vm_prefix = var.infranodes_vm_prefix
   infranodes_os_disk_suffix = var.infranodes_os_disk_suffix
@@ -212,6 +214,8 @@ module "nodes" {
   out_platform_rg_name = module.essentials.out_platform_rg_name
   out_computenodes_nics_ids = module.vnet.out_computenodes_nics_ids
   out_infranodes_nics_ids = module.vnet.out_infranodes_nics_ids
+
+
 
 }
 

--- a/providers/azure/main.tf
+++ b/providers/azure/main.tf
@@ -117,6 +117,7 @@ module "bastions" {
 
   //bastions
   bastions_amount = var.bastions_amount
+  bastions_fault_domains = var.bastions_fault_domains
   bastions_admin_username = var.bastions_admin_username
   bastions_pub_key_controller_path = var.bastions_pub_key_controller_path
 
@@ -135,6 +136,7 @@ module "bastions" {
   //dependencies
   out_platform_rg_name = module.essentials.out_platform_rg_name
   out_bastions_subnet_nics_ids = module.vnet.out_bastions_nics_ids
+
 
 }
 

--- a/providers/azure/vars.tf
+++ b/providers/azure/vars.tf
@@ -85,6 +85,12 @@ variable "bastions_amount" {
   default = "2"
 }
 
+variable "bastions_fault_domains" {
+  type = "string"
+  description = "Number of fault domains for the availibility set of the bastions. This is depending on the region that you are using. https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/managed-disks-common-fault-domain-region-list.md"
+  default = "2"
+}
+
 variable "bastions_vm_type" {
   type = "string"
   description = "Type of the vm for the bastion. Example: Standard_DS1_v2"

--- a/providers/azure/vars.tf
+++ b/providers/azure/vars.tf
@@ -159,6 +159,13 @@ variable "masters_amount" {
   default = "3"
 }
 
+variable "masters_fault_domains" {
+  type = "string"
+  description = "Number of fault domains for the availibility set of the masters. This is depending on the region that you are using. https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/managed-disks-common-fault-domain-region-list.md"
+  default = "2"
+}
+
+
 variable "masters_vm_type" {
   type = "string"
   description = "Type of the vm for the master. Example: Standard_D4_v3"

--- a/providers/azure/vars.tf
+++ b/providers/azure/vars.tf
@@ -240,6 +240,12 @@ variable "computenodes_amount" {
   default = "3"
 }
 
+variable "computenodes_fault_domains" {
+  type = "string"
+  description = "Number of fault domains for the availibility set of the computenodes. This is depending on the region that you are using. https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/managed-disks-common-fault-domain-region-list.md"
+  default = "2"
+}
+
 variable "computenodes_vm_type" {
   type = "string"
   description = "Type of the vm for the compute nodes. Example: Standard_D8_v3"
@@ -306,6 +312,12 @@ variable "infranodes_amount" {
   type    = "string"
   description = "Number of infra nodes to create."
   default = "3"
+}
+
+variable "infranodes_fault_domains" {
+  type = "string"
+  description = "Number of fault domains for the availibility set of the infranodes. This is depending on the region that you are using. https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/managed-disks-common-fault-domain-region-list.md"
+  default = "2"
 }
 
 variable "infranodes_vm_type" {


### PR DESCRIPTION
* moved from multi-zone high-availability to availability sets (multiple racks in one region).
As it turns out, Azure does not support one of the following patterns:
    1. Adding blob-based disks from a storage account to a VM that resists in a specific zones.
    1. Adding both blob-based disks and managed disk to the same VM at the same time.
    1. Creating disks that reside in multiple zones at the same time (zone-redundancy)
    1. Automatic migration of a disk from one zone to another

    This causes the problem, that the Kubernetes Azure Cloud Provider is not able to properly create/manage disks:
        1. The cloud provider has Azure availability-zones support since 1-12 as stated [here](https://github.com/kubernetes/cloud-provider-azure/blob/master/docs/using-availability-zones.md).
        Though, this feature is not reasonable to use, as this only uses node affinities/constraints to add disks only to nodes
        that reside in the same zone as the disk. In case of a zone failure, the disk is also lost. Therefore, the whole point
        of using multiple zones in order to be safe against zone failure, is not met.
        1. OpenShift 3.11 still uses Kubernetes 1.11 and does not have the above feature at all.


* implemented availability sets for vms
* removed zones from all resources